### PR TITLE
Fix broken link and conref

### DIFF
--- a/create-project.md
+++ b/create-project.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-  years: 2015, 2017
-lastupdated: "2017-12-11"
+  years: 2015, 2018
+lastupdated: "2018-01-10"
 
 ---
 
@@ -264,8 +264,8 @@ IBM Watson Explorer
     you must have a valid AlchemyLanguage
     Advanced plan key ID.</p>
   <p class="p">To deploy to Watson Discovery
-    service, you must know the service IBM&reg;
-    Bluemix&reg; space and instance names.</p>
+    service, you must know the service {{site.data.keyword.cloud_notm}}
+    space and instance names.</p>
 </td>
 </tr>
 </table>
@@ -319,7 +319,7 @@ Watson Discovery
     you must have a valid AlchemyLanguage
     Advanced plan key ID.</p>
   <p class="p">To deploy to Watson Discovery
-    service, you must know the service IBM Bluemix
+    service, you must know the service {{site.data.keyword.cloud_notm}}
     space and instance names.</p>
 </td>
 </tr>

--- a/documents-for-annotation.md
+++ b/documents-for-annotation.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-  years: 2015, 2017
-lastupdated: "2017-12-11"
+  years: 2015, 2018
+lastupdated: "2018-01-10"
 
 ---
 
@@ -139,7 +139,7 @@ To add documents to a workspace:
               CAS XMI format, you can
               import the <code>ZIP</code> file that contains the analyzed content. Specify that this is
               the type of content you want to import before you click <b>Import</b>. For details
-              about how to create these files and requirements for importing them, see [Importing pre-annotated documents ![External link icon](../../icons/launch-glyph.svg "External link icon")](wks_preannotate.html#wks_uima){: new_window}.</p>
+              about how to create these files and requirements for importing them, see [Importing pre-annotated documents ![External link icon](../../icons/launch-glyph.svg "External link icon")](preannotation.html#wks_uima){: new_window}.</p>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
- A customer found a broken link and did a PR on the old WKS production repo. I merged that one, so now am cascading the change through the other 3 WKS repos...old staging, new staging, new production.
- Found an instance of Bluemix and fixed it with an IBM Cloud conref.
- Addresses https://github.com/IBM-Bluemix-Docs/knowledge-studio/pull/21